### PR TITLE
feat: configurable RDS storage type, IOPS, and PI retention

### DIFF
--- a/postgres.tf
+++ b/postgres.tf
@@ -50,8 +50,9 @@ module "postgresql" {
 
   instance_class        = var.instance_class
   allocated_storage     = var.allocated_storage
-  storage_type          = "gp2"
-  max_allocated_storage = 0
+  storage_type          = var.storage_type
+  max_allocated_storage = var.max_allocated_storage
+  iops                  = var.iops
   multi_az              = false
   publicly_accessible   = false
   storage_encrypted     = true
@@ -66,7 +67,8 @@ module "postgresql" {
   db_subnet_group_name   = aws_db_subnet_group.private[0].name
 
   backup_retention_period      = var.backup_retention_period
-  performance_insights_enabled = var.performance_insights_enabled
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_retention_period = var.performance_insights_retention_period
   allow_major_version_upgrade  = var.allow_major_version_upgrade
   apply_immediately            = var.apply_immediately
   backup_window                = var.backup_window

--- a/variables.tf
+++ b/variables.tf
@@ -474,6 +474,30 @@ variable "performance_insights_enabled" {
   default     = false
 }
 
+variable "performance_insights_retention_period" {
+  description = "Amount of time in days to retain Performance Insights data (7, 31, 62, 93, 124, 155, 186, 217, 248, 279, 310, 341, 372, 403, 434, 465, 496, 527, 558, 589, 620, 651, 682, 713, 731)"
+  type        = number
+  default     = 7
+}
+
+variable "storage_type" {
+  description = "Storage type for the RDS instance (gp2, gp3, io1, io2)"
+  type        = string
+  default     = "gp2"
+}
+
+variable "max_allocated_storage" {
+  description = "Upper limit for storage autoscaling (0 to disable)"
+  type        = number
+  default     = 0
+}
+
+variable "iops" {
+  description = "Provisioned IOPS for the RDS instance (required for io1/io2 storage types)"
+  type        = number
+  default     = null
+}
+
 variable "postgres_ingress_rules" {
   description = "List of ingress rules"
   type = list(object({


### PR DESCRIPTION
## Summary
- Add `storage_type` variable (default: gp2) to support gp2/gp3/io1/io2
- Add `max_allocated_storage` variable (default: 0) for storage autoscaling
- Add `iops` variable (default: null) for provisioned IOPS (io1/io2)
- Add `performance_insights_retention_period` variable (default: 7 days)

Backwards compatible — all defaults match current hardcoded behavior.

Needed for UMG deployment which uses io2 storage with provisioned IOPS.