### PR TITLE
feat: OpenSearch master type, coordinator nodes, EBS IOPS/throughput

### DIFF
--- a/open-search.tf
+++ b/open-search.tf
@@ -78,7 +78,18 @@ module "opensearch" {
     instance_type            = var.opensearch_instance_type
 
     dedicated_master_count = var.enable_masternodes ? var.number_of_master_nodes : 0
-    dedicated_master_type  = var.enable_masternodes ? var.opensearch_instance_type : ""
+    dedicated_master_type  = var.enable_masternodes ? (var.opensearch_master_instance_type != "" ? var.opensearch_master_instance_type : var.opensearch_instance_type) : ""
+
+    node_options = var.opensearch_coordinator_nodes_enabled ? [
+      {
+        node_type = "coordinator"
+        node_config = {
+          count   = var.opensearch_coordinator_node_count
+          enabled = true
+          type    = var.opensearch_coordinator_instance_type
+        }
+      }
+    ] : []
 
     zone_awareness_config = {
       availability_zone_count = var.zone_awareness_enabled ? var.availability_zone_count : 1
@@ -97,6 +108,8 @@ module "opensearch" {
     ebs_enabled = true
     volume_type = var.ebs_volume_type
     volume_size = var.ebs_volume_size
+    iops        = var.opensearch_ebs_iops
+    throughput  = var.opensearch_ebs_throughput
   }
   encrypt_at_rest = {
     enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -593,6 +593,42 @@ variable "ebs_volume_type" {
   default     = "gp3"
 }
 
+variable "opensearch_ebs_iops" {
+  description = "Provisioned IOPS for OpenSearch EBS volumes"
+  type        = number
+  default     = null
+}
+
+variable "opensearch_ebs_throughput" {
+  description = "Provisioned throughput (MiB/s) for OpenSearch gp3 EBS volumes"
+  type        = number
+  default     = null
+}
+
+variable "opensearch_master_instance_type" {
+  description = "Instance type for dedicated master nodes (defaults to data node instance type if not set)"
+  type        = string
+  default     = ""
+}
+
+variable "opensearch_coordinator_nodes_enabled" {
+  description = "Enable coordinator nodes for OpenSearch"
+  type        = bool
+  default     = false
+}
+
+variable "opensearch_coordinator_node_count" {
+  description = "Number of coordinator nodes"
+  type        = number
+  default     = 0
+}
+
+variable "opensearch_coordinator_instance_type" {
+  description = "Instance type for coordinator nodes"
+  type        = string
+  default     = ""
+}
+
 variable "opensearch_ingress_rules" {
   description = "List of ingress rules"
   type = list(object({


### PR DESCRIPTION
## Summary
- Add `opensearch_master_instance_type` — separate instance type for dedicated master nodes (falls back to data node type if empty)
- Add coordinator node support: `opensearch_coordinator_nodes_enabled`, `opensearch_coordinator_node_count`, `opensearch_coordinator_instance_type`
- Add `opensearch_ebs_iops` and `opensearch_ebs_throughput` for gp3/io1/io2 EBS provisioning

All defaults are backwards compatible (null/empty/false/0).

Needed for UMG OpenSearch deployment.