### PR TITLE
fix: cloudtrail bucket output fails when key doesn't exist in state

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -54,7 +54,7 @@ output "efs_file_system_id" {
 
 output "cloudtrail_bucket_name" {
   description = "Name of S3 bucket for CloudTrail logs"
-  value       = var.enable_security_hub_controls ? aws_s3_bucket.nvisionx_buckets["cloudtrail-logs"].id : null
+  value       = try(aws_s3_bucket.nvisionx_buckets["cloudtrail-logs"].id, null)
 }
 
 output "cloudtrail_access_logs_bucket_name" {


### PR DESCRIPTION
Use try() instead of ternary for cloudtrail_bucket_name output. The ternary evaluates both sides even when condition is false, causing failure when the cloudtrail-logs bucket key doesn't exist in state.