### PR TITLE
Add S3_DOWNLOADS_BUCKET to infra-config configmap

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -130,6 +130,7 @@ resource "kubernetes_config_map" "infra_config" {
       MINIO_LOGO_BUCKET             = aws_s3_bucket.nvisionx_buckets["companylogo"].bucket
       MINIO_CSV_BUCKET              = aws_s3_bucket.nvisionx_buckets["csvfiles"].bucket
       MINIO_APPLICATION_LOGO_BUCKET = aws_s3_bucket.nvisionx_buckets["applogo"].bucket
+      S3_DOWNLOADS_BUCKET           = aws_s3_bucket.nvisionx_buckets["downloads"].bucket
       APPCUES_ACCOUNT_ID            = var.appcues_account_id
       APPCUES_BUNDLE_DOMAIN         = var.appcues_bundle_domain
       APPCUES_API_HOSTNAME          = var.appcues_api_hostname


### PR DESCRIPTION
## Summary
- Adds `S3_DOWNLOADS_BUCKET` entry to the `infra-config` Kubernetes configmap in `eks-cluster.tf`
- The downloads S3 bucket was already being created in `s3.tf` but wasn't exposed in the configmap for application consumption

## Test plan
- [ ] `terraform plan` shows configmap update with new key
- [ ] Verify applications can read `S3_DOWNLOADS_BUCKET` from the configmap after apply