### PR TITLE
Add before_compute to core EKS addons

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -23,10 +23,10 @@ module "eks" {
 
   addons = merge(
     {
-      coredns                = {}
-      eks-pod-identity-agent = {}
-      kube-proxy             = {}
-      vpc-cni                = {}
+      coredns                = { before_compute = true }
+      eks-pod-identity-agent = { before_compute = true }
+      kube-proxy             = { before_compute = true }
+      vpc-cni                = { before_compute = true }
       aws-ebs-csi-driver = {
         # Use Pod Identity instead of IRSA for EBS CSI
         # This replaces the old service_account_role_arn approach


### PR DESCRIPTION
## Summary
- Add `before_compute = true` to vpc-cni, kube-proxy, coredns, and eks-pod-identity-agent addons
- Ensures addons are installed before node groups are created on fresh cluster provisioning

## Context
On fresh environment deploys, node groups and addons were created in parallel. Nodes booted without VPC CNI initialized, causing `NetworkReady=false` and node groups failing with "Unhealthy nodes in the kubernetes cluster". This was the root cause of the sandbox provisioning failures.

## Test plan
- [ ] Existing environments: no-op (addons already exist)
- [ ] New environments: addons created before node groups, nodes should come up Ready