### PR TITLE
Add backup bucket names to EKS infra-config

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -131,6 +131,8 @@ resource "kubernetes_config_map" "infra_config" {
       MINIO_CSV_BUCKET              = aws_s3_bucket.nvisionx_buckets["csvfiles"].bucket
       MINIO_APPLICATION_LOGO_BUCKET = aws_s3_bucket.nvisionx_buckets["applogo"].bucket
       S3_DOWNLOAD_BUCKET            = aws_s3_bucket.nvisionx_buckets["downloads"].bucket
+      S3_POSTGRES_BACKUP_BUCKET     = aws_s3_bucket.nvisionx_buckets["postgres-backup"].bucket
+      S3_OPENSEARCH_BACKUP_BUCKET   = aws_s3_bucket.nvisionx_buckets["os-backup"].bucket
       APPCUES_ACCOUNT_ID            = var.appcues_account_id
       APPCUES_BUNDLE_DOMAIN         = var.appcues_bundle_domain
       APPCUES_API_HOSTNAME          = var.appcues_api_hostname


### PR DESCRIPTION
## Summary
- Add `S3_POSTGRES_BACKUP_BUCKET` and `S3_OPENSEARCH_BACKUP_BUCKET` to the `infra-config` ConfigMap
- These buckets are always created in `s3.tf` so they are added unconditionally alongside the other S3 bucket entries

## Test plan
- [ ] Verify `terraform plan` shows the two new keys added to the `infra-config` ConfigMap
- [ ] Confirm no other resources are affected