### PR TITLE
Add backup bucket names and role ARN to infra-config, inline release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,5 +11,75 @@ permissions:
 
 jobs:
   release:
-    uses: Nvision-x/shared-workflows/.github/workflows/calver-release.yml@main
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
+      - name: Calculate new version
+        id: new_version
+        run: |
+          TODAY=$(date +%Y.%m.%d)
+          DATE_PREFIX="v${TODAY}"
+
+          echo "Today's date prefix: $DATE_PREFIX"
+
+          LATEST_TODAY_TAG=$(git tag -l "${DATE_PREFIX}-*" | sort -t- -k2 -n | tail -1)
+
+          if [ -z "$LATEST_TODAY_TAG" ]; then
+            BUILD_NUM=1
+          else
+            CURRENT_BUILD=$(echo "$LATEST_TODAY_TAG" | sed "s/${DATE_PREFIX}-//")
+            BUILD_NUM=$((CURRENT_BUILD + 1))
+          fi
+
+          NEW_VERSION="${DATE_PREFIX}-${BUILD_NUM}"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      - name: Get previous tag for changelog
+        id: prev_tag
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "Previous tag: $PREV_TAG"
+
+      - name: Generate changelog
+        run: |
+          PREV_TAG="${{ steps.prev_tag.outputs.prev_tag }}"
+
+          if [ -z "$PREV_TAG" ]; then
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" | head -50)
+          else
+            CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s (%h)")
+          fi
+
+          echo "$CHANGELOG" > /tmp/changelog.txt
+
+          echo "Changelog:"
+          echo "$CHANGELOG"
+
+      - name: Create and push tag
+        run: |
+          NEW_VERSION="${{ steps.new_version.outputs.new_version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+          git push origin "$NEW_VERSION"
+
+          echo "Created and pushed tag: $NEW_VERSION"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.new_version.outputs.new_version }}
+          name: Release ${{ steps.new_version.outputs.new_version }}
+          body_path: /tmp/changelog.txt
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -140,10 +140,11 @@ resource "kubernetes_config_map" "infra_config" {
 
     // Add PG & OS only when enabled
     { for k, v in {
-      POSTGRES_HOST       = local.pg_host
-      POSTGRES_USERNAME   = local.pg_username
-      OPENSEARCH_HOST     = local.os_host
-      OPENSEARCH_USERNAME = local.os_username
+      POSTGRES_HOST             = local.pg_host
+      POSTGRES_USERNAME         = local.pg_username
+      POSTGRES_BACKUP_ROLE_ARN  = var.postgres_backup_role_arn != "" ? var.postgres_backup_role_arn : null
+      OPENSEARCH_HOST           = local.os_host
+      OPENSEARCH_USERNAME       = local.os_username
     } : k => v if v != null },
 
     var.ingress_internet_facing != null ? { ingress-internet-facing = var.ingress_internet_facing } : {},


### PR DESCRIPTION
## Summary
- Add `S3_POSTGRES_BACKUP_BUCKET` and `S3_OPENSEARCH_BACKUP_BUCKET` to the `infra-config` ConfigMap
- Add `POSTGRES_BACKUP_ROLE_ARN` conditionally when the variable is set
- Inline the CalVer release workflow to fix private shared-workflows access issue

## Test plan
- [x] Verify `terraform plan` shows the new keys in the `infra-config` ConfigMap
- [x] Verify release workflow triggers on merge to main