### PR TITLE
Encrypt gp3 StorageClass volumes by default

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -244,8 +244,9 @@ resource "kubernetes_storage_class_v1" "gp3" {
   allow_volume_expansion = true
 
   parameters = {
-    type   = "gp3"
-    fsType = "ext4"
+    type      = "gp3"
+    fsType    = "ext4"
+    encrypted = "true"
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `encrypted = "true"` to the default `gp3` StorageClass parameters.
- Unblocks PVC dynamic provisioning that's been failing for ~3+ weeks against the org SCP `DenyCreateUnencryptedEC2`.

## Why
The `gp3` SC had no `encrypted` parameter, so the EBS CSI driver issued `CreateVolume` calls with `Encrypted` unset. The org SCP `DenyCreateUnencryptedEC2` evaluates against the **API request context** (where `ec2:Encrypted=false`) — *before* EC2 applies the account-level encryption-by-default. So every new PVC was being denied:

- `databases-postgres-backup-*` — pending 23d
- `databases-opensearch-backup-*` — pending 17d
- `valkey-content-data` — pending today (new `valkeyInstances.content` instance enabled in nx-application-helm)

Existing bound volumes are encrypted, so this is purely a request-shape mismatch with the SCP. Setting `encrypted = "true"` aligns the request with the SCP intent and makes the SC explicit/region-portable (us-east-2 / us-west-* don't have account-default encryption on).

## Impact on existing workloads
- **None.** The 17 currently-bound PVCs reference their PVs directly; the SC reference is historical once bound. Pulsar/NATS/Prometheus/Valkey data is untouched, no pod restart needed.
- Terraform will plan a **destroy + recreate** of the SC because the `parameters` field is immutable. The gap (~1s) only affects PVCs being dynamically provisioned at that exact moment; controller retries handle it transparently.

## Test plan
- [ ] `terraform plan` shows `kubernetes_storage_class_v1.gp3` must be replaced (params change), no other drift.
- [ ] After apply on integration: `kubectl get sc gp3 -o yaml` shows `parameters.encrypted: "true"`.
- [ ] The 3 pending PVCs (`valkey-content-data`, postgres backup, opensearch backup) bind within ~1 min.
- [ ] `valkey-content-*` pod transitions to Running.
- [ ] Existing pods (pulsar-bookie, nats, valkey-jobengine, prometheus) remain Running with no restarts.
- [ ] `aws ec2 describe-volumes` on the freshly-provisioned volume returns `Encrypted: True`.

## Rollout
1. Merge → apply on integration first.
2. Validate (test plan above).
3. Same change in downstream env stacks if they pin a copy: `nx-development-tf`, `nx-uat-tf`, `nx-sandbox-tf`, `nx-integration-tf`, `nx-demo-tf`, `nx-demo2-tf`, `nx-dana-tf`.

## Related
- Org SCPs: `p-6esq55xa`, `p-vtbvkrki` (DenyCreateUnencryptedEC2)
- Trigger today: `valkey-content` instance enabled by default in `nx-application-helm` commit `c54146c2`.