### PR TITLE
feat: add Neptune Serverless, S3 Vectors, knowledge-hub Pod Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ module "nx" {
 
 ---
 
+## Manual prerequisites
+
+A few things this module does not (and cannot) do for you:
+
+- **Bedrock model access** — Foundation model access must be requested manually in the Bedrock console per region, per model (Console → Bedrock → Model access → "Request model access"). IAM permissions alone are not sufficient; `InvokeModel` calls will return `AccessDeniedException` until the model is enabled at the account level. This is a one-time, per-region grant.
+- **S3 Vectors indexes** — `aws_s3vectors_vector_bucket` creates the bucket only. Indexes carry dimension and distance-metric choices that are per-use-case and belong with the application that owns the data; create them from the app (boto3 / SDK) or with a small bootstrap script.
+- **Neptune IAM-auth bootstrap** — Newly created Neptune clusters need an initial role/identity mapped to the database. The cluster comes up with IAM auth enabled but no app principal granted; load the first identity from a bastion or one-shot pod using `awscurl` / the Neptune CLI.
+
+---
+
 ## Requirements
 
 | Name | Version |

--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ module "nx" {
 
 A few things this module does not (and cannot) do for you:
 
-- **Bedrock model access** — Foundation model access must be requested manually in the Bedrock console per region, per model (Console → Bedrock → Model access → "Request model access"). IAM permissions alone are not sufficient; `InvokeModel` calls will return `AccessDeniedException` until the model is enabled at the account level. This is a one-time, per-region grant.
 - **S3 Vectors indexes** — `aws_s3vectors_vector_bucket` creates the bucket only. Indexes carry dimension and distance-metric choices that are per-use-case and belong with the application that owns the data; create them from the app (boto3 / SDK) or with a small bootstrap script.
 - **Neptune IAM-auth bootstrap** — Newly created Neptune clusters need an initial role/identity mapped to the database. The cluster comes up with IAM auth enabled but no app principal granted; load the first identity from a bastion or one-shot pod using `awscurl` / the Neptune CLI.
+
+> Bedrock note: AWS no longer requires a per-model console grant to invoke foundation models — IAM permissions alone are sufficient.
 
 ---
 

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -159,7 +159,10 @@ resource "kubernetes_config_map" "infra_config" {
     var.ingress_wafv2_acl_arn != null ? { ingress-wafv2-acl-arn = var.ingress_wafv2_acl_arn } : {},
     var.ingress_host != null ? { ingress-host = var.ingress_host } : {},
     { snapshot-repository-name = var.snapshot_repository_name },
-    { aws-region = var.region }
+    # aws-region kept for backward compat; AWS_REGION added so envFrom works
+    # (envFrom silently skips keys that aren't valid env var names, e.g. hyphenated)
+    { aws-region = var.region },
+    { AWS_REGION = var.region }
   )
 }
 

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -114,6 +114,11 @@ locals {
 
   os_host     = var.enable_opensearch ? module.opensearch[0].domain_endpoint : null
   os_username = var.enable_opensearch ? var.master_user_name : null
+
+  neptune_host = var.enable_neptune ? aws_neptune_cluster.this[0].endpoint : null
+  neptune_port = var.enable_neptune ? tostring(aws_neptune_cluster.this[0].port) : null
+
+  s3_vectors_bucket = var.enable_s3_vectors ? aws_s3vectors_vector_bucket.this[0].vector_bucket_name : null
 }
 
 
@@ -138,12 +143,15 @@ resource "kubernetes_config_map" "infra_config" {
       APPCUES_API_HOSTNAME          = var.appcues_api_hostname
     },
 
-    // Add PG & OS only when enabled
+    // Add PG, OS, Neptune, S3 Vectors only when enabled
     { for k, v in {
-      POSTGRES_HOST     = local.pg_host
-      POSTGRES_USERNAME = local.pg_username
-      OPENSEARCH_HOST   = local.os_host
+      POSTGRES_HOST       = local.pg_host
+      POSTGRES_USERNAME   = local.pg_username
+      OPENSEARCH_HOST     = local.os_host
       OPENSEARCH_USERNAME = local.os_username
+      NEPTUNE_HOST        = local.neptune_host
+      NEPTUNE_PORT        = local.neptune_port
+      S3_VECTORS_BUCKET   = local.s3_vectors_bucket
     } : k => v if v != null },
 
     var.ingress_internet_facing != null ? { ingress-internet-facing = var.ingress_internet_facing } : {},

--- a/neptune.tf
+++ b/neptune.tf
@@ -101,7 +101,9 @@ resource "aws_iam_policy" "neptune_connect" {
 }
 
 resource "aws_iam_role_policy_attachment" "knowledge_hub_neptune" {
-  count      = var.enable_neptune && var.enable_knowledge_hub_pod_identity && var.knowledge_hub_role_arn != "" ? 1 : 0
+  # count uses only plan-time-known vars; consumer must pass a real role ARN
+  # when enable_knowledge_hub_pod_identity is true, else the split fails at apply.
+  count      = var.enable_neptune && var.enable_knowledge_hub_pod_identity ? 1 : 0
   role       = split("/", var.knowledge_hub_role_arn)[1]
   policy_arn = aws_iam_policy.neptune_connect[0].arn
 }

--- a/neptune.tf
+++ b/neptune.tf
@@ -1,0 +1,107 @@
+# Neptune Serverless cluster — graph store for knowledge-hub and similar workloads.
+# IAM database authentication is enabled so pods authenticate via their Pod
+# Identity role (no static credentials). Workload-specific connect permissions
+# live on the role in nx-iam-tf, scoped to this cluster's resource ID.
+
+resource "aws_neptune_subnet_group" "this" {
+  count       = var.enable_neptune ? 1 : 0
+  name        = var.neptune_subnet_group_name
+  subnet_ids  = var.private_subnets
+  description = "Subnet group for ${var.neptune_cluster_identifier}"
+  tags        = var.tags
+}
+
+resource "aws_security_group" "neptune" {
+  count       = var.enable_neptune ? 1 : 0
+  name        = var.neptune_security_group_name
+  description = "Allow Neptune (8182) access"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 8182
+    to_port     = 8182
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr_block]
+    description = "Neptune endpoint access from VPC"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+resource "aws_neptune_cluster" "this" {
+  count                               = var.enable_neptune ? 1 : 0
+  cluster_identifier                  = var.neptune_cluster_identifier
+  engine                              = "neptune"
+  engine_version                      = var.neptune_engine_version
+  neptune_subnet_group_name           = aws_neptune_subnet_group.this[0].name
+  vpc_security_group_ids              = [aws_security_group.neptune[0].id]
+  storage_encrypted                   = true
+  iam_database_authentication_enabled = true
+  backup_retention_period             = var.neptune_backup_retention_period
+  preferred_backup_window             = var.neptune_backup_window
+  preferred_maintenance_window        = var.neptune_maintenance_window
+  skip_final_snapshot                 = var.neptune_skip_final_snapshot
+  apply_immediately                   = var.neptune_apply_immediately
+  deletion_protection                 = var.neptune_deletion_protection
+
+  serverless_v2_scaling_configuration {
+    min_capacity = var.neptune_min_ncu
+    max_capacity = var.neptune_max_ncu
+  }
+
+  tags = var.tags
+}
+
+resource "aws_neptune_cluster_instance" "this" {
+  count              = var.enable_neptune ? var.neptune_instance_count : 0
+  identifier         = "${var.neptune_cluster_identifier}-${count.index + 1}"
+  cluster_identifier = aws_neptune_cluster.this[0].id
+  engine             = "neptune"
+  instance_class     = "db.serverless"
+  apply_immediately  = var.neptune_apply_immediately
+  tags               = var.tags
+}
+
+# Neptune IAM-auth policy attached to the knowledge-hub role.
+# Lives here (not in nx-iam-tf) because the policy resource ARN depends on
+# aws_neptune_cluster.this[0].cluster_resource_id, which only exists after
+# Neptune is provisioned. Pulling this into nx-iam-tf would create a cycle.
+
+resource "aws_iam_policy" "neptune_connect" {
+  count = var.enable_neptune && var.enable_knowledge_hub_pod_identity ? 1 : 0
+  name  = "${var.neptune_cluster_identifier}-connect"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "NeptuneDataAccess"
+        Effect = "Allow"
+        Action = [
+          "neptune-db:connect",
+          "neptune-db:ReadDataViaQuery",
+          "neptune-db:WriteDataViaQuery",
+          "neptune-db:DeleteDataViaQuery",
+          "neptune-db:GetEngineStatus",
+          "neptune-db:GetQueryStatus"
+        ]
+        Resource = "arn:aws:neptune-db:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_neptune_cluster.this[0].cluster_resource_id}/*"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "knowledge_hub_neptune" {
+  count      = var.enable_neptune && var.enable_knowledge_hub_pod_identity && var.knowledge_hub_role_arn != "" ? 1 : 0
+  role       = split("/", var.knowledge_hub_role_arn)[1]
+  policy_arn = aws_iam_policy.neptune_connect[0].arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -66,3 +66,42 @@ output "cloudtrail_kms_key_arn" {
   description = "ARN of KMS key for CloudTrail encryption"
   value       = var.enable_security_hub_controls ? aws_kms_key.cloudtrail[0].arn : null
 }
+
+# --------------------- Neptune Serverless -----------------------------
+
+output "neptune_cluster_endpoint" {
+  description = "Neptune cluster writer endpoint"
+  value       = var.enable_neptune ? aws_neptune_cluster.this[0].endpoint : null
+}
+
+output "neptune_cluster_reader_endpoint" {
+  description = "Neptune cluster reader endpoint"
+  value       = var.enable_neptune ? aws_neptune_cluster.this[0].reader_endpoint : null
+}
+
+output "neptune_cluster_port" {
+  description = "Neptune cluster port"
+  value       = var.enable_neptune ? aws_neptune_cluster.this[0].port : null
+}
+
+output "neptune_cluster_resource_id" {
+  description = "Neptune cluster resource ID — used for IAM neptune-db:* resource ARNs"
+  value       = var.enable_neptune ? aws_neptune_cluster.this[0].cluster_resource_id : null
+}
+
+output "neptune_cluster_arn" {
+  description = "Neptune cluster ARN"
+  value       = var.enable_neptune ? aws_neptune_cluster.this[0].arn : null
+}
+
+# --------------------- S3 Vectors -------------------------------------
+
+output "s3_vectors_bucket_name" {
+  description = "S3 Vectors vector bucket name"
+  value       = var.enable_s3_vectors ? aws_s3vectors_vector_bucket.this[0].vector_bucket_name : null
+}
+
+output "s3_vectors_bucket_arn" {
+  description = "S3 Vectors vector bucket ARN"
+  value       = var.enable_s3_vectors ? aws_s3vectors_vector_bucket.this[0].arn : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -102,6 +102,6 @@ output "s3_vectors_bucket_name" {
 }
 
 output "s3_vectors_bucket_arn" {
-  description = "S3 Vectors vector bucket ARN"
-  value       = var.enable_s3_vectors ? aws_s3vectors_vector_bucket.this[0].arn : null
+  description = "S3 Vectors vector bucket ARN (constructed; the resource doesn't export .arn directly)"
+  value       = var.enable_s3_vectors ? "arn:aws:s3vectors:${var.region}:${data.aws_caller_identity.current.account_id}:bucket/${aws_s3vectors_vector_bucket.this[0].vector_bucket_name}" : null
 }

--- a/pod-identity-associations.tf
+++ b/pod-identity-associations.tf
@@ -106,3 +106,25 @@ resource "aws_eks_pod_identity_association" "bedrock" {
 
   depends_on = [module.eks]
 }
+
+################################################################################
+# Knowledge Hub Pod Identity Association
+################################################################################
+
+locals {
+  knowledge_hub_sa = var.enable_knowledge_hub_pod_identity && var.knowledge_hub_service_account != "" ? {
+    namespace       = split(":", var.knowledge_hub_service_account)[0]
+    service_account = split(":", var.knowledge_hub_service_account)[1]
+  } : null
+}
+
+resource "aws_eks_pod_identity_association" "knowledge_hub" {
+  count = local.knowledge_hub_sa != null ? 1 : 0
+
+  cluster_name    = module.eks.cluster_name
+  namespace       = local.knowledge_hub_sa.namespace
+  service_account = local.knowledge_hub_sa.service_account
+  role_arn        = var.knowledge_hub_role_arn
+
+  depends_on = [module.eks]
+}

--- a/s3-vectors.tf
+++ b/s3-vectors.tf
@@ -1,0 +1,14 @@
+# S3 Vectors bucket — native vector storage for embeddings/RAG workloads.
+# Indexes are intentionally not created here: dimension and distance metric
+# are per-use-case decisions that belong with the application that owns them.
+
+resource "aws_s3vectors_vector_bucket" "this" {
+  count              = var.enable_s3_vectors ? 1 : 0
+  vector_bucket_name = var.s3_vectors_bucket_name
+
+  encryption_configuration {
+    sse_type = "AES256"
+  }
+
+  tags = var.tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -943,6 +943,126 @@ variable "bedrock_guardrail_arns" {
   default     = ["arn:aws:bedrock:*:*:guardrail/*"]
 }
 
+# ----------------------------- Neptune Serverless -----------------------
+
+variable "enable_neptune" {
+  description = "Create a Neptune Serverless cluster and related resources"
+  type        = bool
+  default     = false
+}
+
+variable "neptune_cluster_identifier" {
+  description = "Identifier for the Neptune cluster"
+  type        = string
+  default     = ""
+}
+
+variable "neptune_subnet_group_name" {
+  description = "Name for the Neptune DB subnet group"
+  type        = string
+  default     = ""
+}
+
+variable "neptune_security_group_name" {
+  description = "Name for the Neptune security group"
+  type        = string
+  default     = ""
+}
+
+variable "neptune_engine_version" {
+  description = "Neptune engine version. Leave null to let AWS select the default"
+  type        = string
+  default     = null
+}
+
+variable "neptune_min_ncu" {
+  description = "Minimum Neptune Capacity Units for serverless scaling (half-step increments, min 1.0)"
+  type        = number
+  default     = 1.0
+}
+
+variable "neptune_max_ncu" {
+  description = "Maximum Neptune Capacity Units for serverless scaling"
+  type        = number
+  default     = 16.0
+}
+
+variable "neptune_instance_count" {
+  description = "Number of db.serverless instances in the cluster"
+  type        = number
+  default     = 1
+}
+
+variable "neptune_backup_retention_period" {
+  description = "Days to retain Neptune automated backups"
+  type        = number
+  default     = 1
+}
+
+variable "neptune_backup_window" {
+  description = "Preferred Neptune backup window (UTC)"
+  type        = string
+  default     = "07:00-08:00"
+}
+
+variable "neptune_maintenance_window" {
+  description = "Preferred Neptune maintenance window"
+  type        = string
+  default     = "sun:08:30-sun:09:30"
+}
+
+variable "neptune_skip_final_snapshot" {
+  description = "Skip the final snapshot when destroying the Neptune cluster"
+  type        = bool
+  default     = true
+}
+
+variable "neptune_apply_immediately" {
+  description = "Apply Neptune modifications immediately rather than at the next maintenance window"
+  type        = bool
+  default     = false
+}
+
+variable "neptune_deletion_protection" {
+  description = "Enable deletion protection on the Neptune cluster"
+  type        = bool
+  default     = false
+}
+
+# ----------------------------- S3 Vectors -------------------------------
+
+variable "enable_s3_vectors" {
+  description = "Create an S3 Vectors vector bucket for embeddings storage"
+  type        = bool
+  default     = false
+}
+
+variable "s3_vectors_bucket_name" {
+  description = "Name for the S3 Vectors vector bucket"
+  type        = string
+  default     = ""
+}
+
+# ----------------------------- Knowledge Hub Pod Identity ---------------
+
+variable "enable_knowledge_hub_pod_identity" {
+  description = "Create the Pod Identity association for the knowledge-hub workload role"
+  type        = bool
+  default     = false
+}
+
+variable "knowledge_hub_role_arn" {
+  description = "IAM role ARN for the knowledge-hub workload (from nx-iam-tf)"
+  type        = string
+  default     = ""
+}
+
+variable "knowledge_hub_service_account" {
+  description = "namespace:serviceaccount pair for the knowledge-hub workload"
+  type        = string
+  default     = ""
+}
+
 # ----------------------------- Appcues ----------------------------------
 
 variable "appcues_account_id" {


### PR DESCRIPTION
## Summary
Three new optional resources for graph + vector workloads (initial driver: Ben's knowledge-hub integration in dev):

- **Neptune Serverless** (`enable_neptune`) — cluster + `db.serverless` instance + subnet group + SG (8182 from VPC CIDR), IAM database authentication enabled, serverless v2 scaling via `neptune_min_ncu`/`max_ncu`
- **S3 Vectors** (`enable_s3_vectors`) — `aws_s3vectors_vector_bucket` with AES256. Indexes intentionally not created (dim + distance are per-use-case)
- **Knowledge-hub Pod Identity** (`enable_knowledge_hub_pod_identity`) — association linking the workload SA to the role created in `nx-iam-tf` (paired PR), plus the Neptune IAM-auth policy + attachment (kept here because `cluster_resource_id` only exists after Neptune is provisioned)

## Manual prerequisites (documented in README)
- Bedrock model access must be granted in the console per region — IAM permissions alone are not sufficient
- S3 Vectors indexes are created from the app, not by this module
- Neptune IAM identity bootstrap needs a one-shot pod/bastion to register the first principal

## Test plan
- [ ] CI Terraform Plan green
- [ ] After merge + tag, bump `nx-development-tf` to the new tag and verify plan creates Neptune + S3 Vectors + knowledge-hub Pod Identity association
- [ ] Verify Neptune SG only allows 8182 from VPC CIDR, no public access