### PR TITLE
eks: expose content-cache bucket names via infra-config configmap

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -138,6 +138,8 @@ resource "kubernetes_config_map" "infra_config" {
       S3_DOWNLOAD_BUCKET            = aws_s3_bucket.nvisionx_buckets["downloads"].bucket
       S3_POSTGRES_BACKUP_BUCKET     = aws_s3_bucket.nvisionx_buckets["postgres-backup"].bucket
       S3_OPENSEARCH_BACKUP_BUCKET   = aws_s3_bucket.nvisionx_buckets["os-backup"].bucket
+      S3_RAW_CONTENT_CACHE_BUCKET   = aws_s3_bucket.nvisionx_buckets["raw-content-cache"].bucket
+      S3_TEXT_CONTENT_CACHE_BUCKET  = aws_s3_bucket.nvisionx_buckets["text-content-cache"].bucket
       APPCUES_ACCOUNT_ID            = var.appcues_account_id
       APPCUES_BUNDLE_DOMAIN         = var.appcues_bundle_domain
       APPCUES_API_HOSTNAME          = var.appcues_api_hostname


### PR DESCRIPTION
## Summary

Follow-up to #40 — the new `raw-content-cache` and `text-content-cache` S3 buckets exist, but the `infra-config` ConfigMap (which workloads consume via `envFrom`) didn't include their names. Workloads can't reach S3 buckets they can't name.

Adds two keys to the `infra-config` ConfigMap data:

- `S3_RAW_CONTENT_CACHE_BUCKET` → `nvisionx-raw-content-cache-<hex>`
- `S3_TEXT_CONTENT_CACHE_BUCKET` → `nvisionx-text-content-cache-<hex>`

Naming follows the existing `S3_*_BUCKET` convention used by `S3_POSTGRES_BACKUP_BUCKET`, `S3_OPENSEARCH_BACKUP_BUCKET`, `S3_DOWNLOAD_BUCKET`.

## Consumer impact

- Content Service pod spec needs `envFrom.configMapRef.name: infra-config` (probably already does for other S3 env vars) and reads `$S3_RAW_CONTENT_CACHE_BUCKET` / `$S3_TEXT_CONTENT_CACHE_BUCKET`.
- Connectors in content mode same — read `$S3_RAW_CONTENT_CACHE_BUCKET` for write target.

## Open env bumps that should pull this in

Both currently approved at `v2026.05.27-3`:
- nx-development-tf#34 — recommend re-bumping to the new tag this PR cuts
- nx-integration-tf#40 — recommend re-bumping to the new tag this PR cuts

If we merge those first, they'll need a follow-up bump anyway, so cleaner to merge this PR first, cut a new tag, then bump both env PRs to it.

## Test plan

- [ ] CI plan in dev shows: 1 in-place update to `kubernetes_config_map.infra_config` adding the two new keys (no recreation, no other changes)
- [ ] `kubectl -n default get cm infra-config -o yaml` shows both new keys after apply