### PR TITLE
feat(eks): expose coredns configuration_values for custom Corefile

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -23,7 +23,10 @@ module "eks" {
 
   addons = merge(
     {
-      coredns                = { before_compute = true }
+      coredns = merge(
+        { before_compute = true },
+        var.coredns_configuration_values != null ? { configuration_values = var.coredns_configuration_values } : {}
+      )
       eks-pod-identity-agent = { before_compute = true }
       kube-proxy             = { before_compute = true }
       vpc-cni                = { before_compute = true }

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,12 @@ variable "eks_access_principal_arn" {
   default     = null
 }
 
+variable "coredns_configuration_values" {
+  description = "Optional JSON-encoded configuration_values for the EKS coredns add-on. Use to customise the Corefile (e.g. forward zones to on-prem DNS). When null, the add-on runs with its default configuration."
+  type        = string
+  default     = null
+}
+
 variable "namespace" {
   description = "Namespace where resources will be created"
   type        = string


### PR DESCRIPTION
## Summary
Adds an optional `coredns_configuration_values` input variable wired into the EKS managed coredns add-on. Lets downstream consumers inject a custom Corefile via `configuration_values` — typically to forward customer-specific zones to on-prem DNS over a site-to-site VPN.

**Backwards-compatible:** default is `null` → add-on behaves exactly as before for every existing consumer (no plan-diff on apply).

Mirrors the existing `configuration_values` pattern already used a few lines below for the `amazon-cloudwatch-observability` add-on, so no new conventions introduced.

## Why
First customer trigger is **NXE-2182** (SCB&T): `*.scbandt.com` resolves to Cloudflare from inside the VPC because the AWS VPC resolver has no forwarding rule for that zone. VPN is up and on-prem DNS (`172.25.140.8`) is already reachable from pods — only DNS forwarding is missing.

We picked the EKS-add-on `configuration_values` path over a Route 53 Resolver outbound endpoint (~$180/mo) because for a single domain it gives equivalent persistence at no extra cost (survives add-on resets, EKS upgrades, configmap wipes — EKS re-applies the Corefile on every reconcile). Route 53 Resolver stays in our back pocket for the day we need VPC-wide forwarding or multi-VPC RAM-sharing.

## Consumer-side usage (example, lands in nx-ssb-tf as a follow-up PR)
```hcl
module "nx" {
  source = "git::https://github.com/Nvision-x/nx-infra-tf.git?ref=<this-tag>"
  # ...
  coredns_configuration_values = jsonencode({
    corefile = <<-EOT
      .:53 {
        errors
        health { lameduck 5s }
        ready
        kubernetes cluster.local in-addr.arpa ip6.arpa {
          pods insecure
          fallthrough in-addr.arpa ip6.arpa
        }
        prometheus :9153
        forward . /etc/resolv.conf
        cache 30
        loop
        reload
        loadbalance
      }
      scbandt.com:53 {
        errors
        cache 30
        forward . 172.25.140.8
      }
    EOT
  })
}
```

Confirmed against the schema for the currently-deployed add-on version (`v1.14.2-eksbuild.4`) via `aws eks describe-addon-configuration` — the `corefile` key takes the full Corefile as a string.

## Test plan
- [x] `terraform validate` passes locally on the feature branch (only pre-existing deprecation warnings for `kubernetes_namespace`)
- [ ] Reviewer: confirm `terraform plan` against an existing consumer (e.g. nx-dana-tf or nx-uat-tf) shows **no diff** with the variable left at its default `null` — proves backwards-compat
- [ ] After merge: cut a new tag (suggest `v2026.05.28-1` per existing convention), then bump `nx-ssb-tf` pin in the follow-up PR to validate end-to-end against `eks-ssb`

Refs NXE-2182.