### PR TITLE
feat: create Kubernetes ServiceAccount for knowledge-hub

### DIFF
--- a/knowledge-hub-service-account.tf
+++ b/knowledge-hub-service-account.tf
@@ -1,0 +1,44 @@
+# Kubernetes ServiceAccount for the knowledge-hub workload.
+# The Pod Identity association in pod-identity-associations.tf references this
+# SA by name; without the SA actually existing in the cluster, pods that set
+# spec.serviceAccountName: knowledge-hub are rejected with
+#   "error looking up service account default/knowledge-hub: ... not found"
+# Mirrors the kubernetes_service_account.bedrock pattern.
+
+locals {
+  knowledge_hub_sa_create = var.enable_knowledge_hub_pod_identity && var.create_knowledge_hub_service_account && var.knowledge_hub_service_account != ""
+  knowledge_hub_sa_ns     = local.knowledge_hub_sa_create ? split(":", var.knowledge_hub_service_account)[0] : ""
+  knowledge_hub_sa_name   = local.knowledge_hub_sa_create ? split(":", var.knowledge_hub_service_account)[1] : ""
+}
+
+resource "kubernetes_service_account" "knowledge_hub" {
+  count = local.knowledge_hub_sa_create ? 1 : 0
+
+  metadata {
+    name      = local.knowledge_hub_sa_name
+    namespace = local.knowledge_hub_sa_ns
+
+    labels = {
+      "app.kubernetes.io/name"       = local.knowledge_hub_sa_name
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "knowledge-hub"
+    }
+  }
+
+  automount_service_account_token = true
+
+  lifecycle {
+    # Helm/app may add its own labels/annotations; don't fight them.
+    ignore_changes = [metadata[0].labels, metadata[0].annotations]
+  }
+}
+
+# Adopt the SA if it was created out-of-band (e.g. manual kubectl create sa
+# before this resource existed in TF). Safe no-op once the SA is in state.
+# Uses for_each so envs with the feature disabled (count=0) don't try to
+# import into a non-existent resource index.
+import {
+  for_each = local.knowledge_hub_sa_create ? { adopt = "${local.knowledge_hub_sa_ns}/${local.knowledge_hub_sa_name}" } : {}
+  to       = kubernetes_service_account.knowledge_hub[0]
+  id       = each.value
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1069,6 +1069,12 @@ variable "knowledge_hub_service_account" {
   default     = ""
 }
 
+variable "create_knowledge_hub_service_account" {
+  description = "Create the Kubernetes ServiceAccount for knowledge-hub. Defaults to true so the Pod Identity association has something to bind to. Set false if the workload's Helm chart owns the SA."
+  type        = bool
+  default     = true
+}
+
 # ----------------------------- Appcues ----------------------------------
 
 variable "appcues_account_id" {


### PR DESCRIPTION
## Summary
Creates the `kubernetes_service_account` for the knowledge-hub workload, mirroring the `kubernetes_service_account.bedrock` pattern. The Pod Identity association already references `default:knowledge-hub` but the K8s SA object wasn't being created, so pods setting `serviceAccountName: knowledge-hub` were rejected by the kubelet.

## Why this matters
Without the SA object the workload's deployment fails immediately with:

```
error looking up service account default/knowledge-hub:
serviceaccount "knowledge-hub" not found
```

We hit this in dev today during initial integration and unblocked it by `kubectl create sa knowledge-hub -n default`. This PR codifies that so the SA is reproducible per-env.

## Behaviour
- `enable_knowledge_hub_pod_identity = true` + `create_knowledge_hub_service_account = true` (default) → SA is created
- `create_knowledge_hub_service_account = false` → opt out, app's Helm chart owns the SA
- `enable_knowledge_hub_pod_identity = false` → no SA, no Pod Identity association, no-op

## Import block
A `for_each`-gated `import` block adopts the manually-created SA on dev into Terraform state on first apply, so the apply doesn't fail with `AlreadyExists`. For envs where the SA doesn't exist yet, `for_each` keeps the import inert so the resource is created normally.

## Test plan
- [ ] CI Terraform Plan green
- [ ] Plan on dev shows the SA being **imported** (not created), no other drift
- [ ] After apply, `kubectl get sa knowledge-hub -n default` still exists with TF-managed labels