### PR TITLE
fix(eks): preserve admin access entry across count->for_each migration

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -89,11 +89,38 @@ resource "aws_security_group_rule" "eks_nodes_all_vpc_ingress" {
   description       = "Allow all traffic from within VPC for node-to-node/pod-to-pod communication"
 }
 
+# This resource was migrated from `count` (single principal, address `[0]`) to
+# `for_each` (map keyed by name). Without the moved blocks below, Terraform reads
+# the address change `[0]` -> `["admin"]` as destroy+recreate, which deletes the
+# admin EKS access entry mid-apply and locks operators out of the cluster. The
+# moved blocks carry the existing object to the new key instead. They assume the
+# previously-single principal is passed under the map key "admin" (the convention
+# in the root configs); an env that used a different key must adjust accordingly.
+# Already-migrated states have nothing at `[0]`, so the moved block is a safe no-op.
+moved {
+  from = aws_eks_access_entry.access[0]
+  to   = aws_eks_access_entry.access["admin"]
+}
+
+moved {
+  from = aws_eks_access_policy_association.access_policy[0]
+  to   = aws_eks_access_policy_association.access_policy["admin"]
+}
+
 resource "aws_eks_access_entry" "access" {
   for_each      = var.eks_access_principal_arn
   cluster_name  = module.eks.cluster_name
   principal_arn = each.value
   type          = "STANDARD"
+
+  # Guardrail: refuse to destroy an admin access entry. A future address change
+  # or an accidental removal will then fail the plan loudly instead of silently
+  # revoking cluster access (the failure mode that originally locked us out). To
+  # intentionally revoke a principal, remove it from the map AND drop this block
+  # in the same change.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_eks_access_policy_association" "access_policy" {


### PR DESCRIPTION
## Problem

The cluster admin access entry was refactored from a **`count`** resource (address `aws_eks_access_entry.access[0]`) to a **`for_each`** map (address `aws_eks_access_entry.access["admin"]`) — without `moved` blocks.

Terraform interprets that address change as **destroy + recreate**. On apply it deletes the existing admin EKS access entry and its `AmazonEKSClusterAdminPolicy` association before recreating them under the new key. If the recreate doesn't land cleanly, the admin principal is left with **no access entry at all** — the cluster rejects it with `the server has asked for the client to provide credentials`. This already locked admins out of one environment.

It's also latent for **every environment still on the pre-`for_each` module version**: their next apply will destroy/recreate the admin entry the same way.

## Fix

1. **`moved` blocks** — carry the existing objects from `[0]` to `["admin"]` so the migration is a state move, not destroy/recreate:
   ```hcl
   moved {
     from = aws_eks_access_entry.access[0]
     to   = aws_eks_access_entry.access["admin"]
   }
   moved {
     from = aws_eks_access_policy_association.access_policy[0]
     to   = aws_eks_access_policy_association.access_policy["admin"]
   }
   ```
   Safe for already-migrated states (nothing at `[0]` → no-op) and clean for not-yet-migrated states (state move, no access loss).

2. **`prevent_destroy`** on the access entry — a future address change or accidental map removal now **fails the plan loudly** instead of silently revoking cluster access (the original failure mode).

## Assumptions / caveats

- The `moved` blocks target map key **`"admin"`** — the convention the root configs use for the previously-single principal (`merge({ admin = var.eks_access_principal_arn }, ...)`). An environment whose pre-existing single principal was passed under a different key would need to adjust.
- `prevent_destroy` is resource-wide (covers all `for_each` instances). To intentionally revoke a principal, remove it from the map **and** drop the `prevent_destroy` block in the same change.

## Notes for rollout

- Module-only change. Consumers pick it up on their next ref bump; the plan should show `moved`/no-op for the admin entry rather than destroy/recreate.
- An environment that has **already** lost its admin entry (state no longer has `[0]`) is unaffected by the `moved` block — it just needs a normal apply to create `["admin"]` (or an out-of-band re-add to unblock first).
