### PR TITLE
fix: remove import block from module (only valid in root module)

### DIFF
--- a/knowledge-hub-service-account.tf
+++ b/knowledge-hub-service-account.tf
@@ -32,13 +32,3 @@ resource "kubernetes_service_account" "knowledge_hub" {
     ignore_changes = [metadata[0].labels, metadata[0].annotations]
   }
 }
-
-# Adopt the SA if it was created out-of-band (e.g. manual kubectl create sa
-# before this resource existed in TF). Safe no-op once the SA is in state.
-# Uses for_each so envs with the feature disabled (count=0) don't try to
-# import into a non-existent resource index.
-import {
-  for_each = local.knowledge_hub_sa_create ? { adopt = "${local.knowledge_hub_sa_ns}/${local.knowledge_hub_sa_name}" } : {}
-  to       = kubernetes_service_account.knowledge_hub[0]
-  id       = each.value
-}


### PR DESCRIPTION
## Problem

`knowledge-hub-service-account.tf` contains an `import {}` block. Terraform only permits import blocks in the **root** module, so one in this child module fails config validation for **every consumer**:

```
Error: Invalid import configuration
  on .terraform/modules/nx/knowledge-hub-service-account.tf line 40:
  40: import {
An import block was detected in "module.nx". Import blocks are only allowed in the root module.
```

This breaks `init`/`plan` **even when the knowledge-hub feature is disabled** — it's a static config-validation rule, not runtime-gated by the `count`/`for_each`. It's present in `v2026.06.03-2` (a ref consumers currently pin), so their pipelines fail to plan.

## Fix

- Remove the `import {}` block from the module.
- `kubernetes_service_account.knowledge_hub` (count-gated) is otherwise unchanged — disabled envs are unaffected; enabled envs still create the SA.

## Notes

- To adopt a knowledge-hub SA that was created out-of-band, do it from the consuming **root** config — a root-level import block or a one-off `terraform import 'module.nx.kubernetes_service_account.knowledge_hub[0]' <ns>/<name>`.
- If an environment has the feature enabled **and** the SA already exists out-of-band (e.g. created by Helm), its next apply would try to create the SA and could hit "already exists" — handle that env with the root-level import above. Worth a follow-up to decide whether Terraform or Helm should own that SA.
- `terraform fmt` clean.
