### PR TITLE
Encrypt gp3 StorageClass volumes by default

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -283,8 +283,9 @@ resource "kubernetes_storage_class_v1" "gp3" {
   allow_volume_expansion = true
 
   parameters = {
-    type   = "gp3"
-    fsType = "ext4"
+    type      = "gp3"
+    fsType    = "ext4"
+    encrypted = "true"
   }
 }
 


### PR DESCRIPTION
Adds `encrypted = "true"` to the default gp3 `kubernetes_storage_class_v1` so all new EBS volumes provisioned through the ebs.csi.aws.com provisioner are encrypted at rest.

Previously gp3 PVCs landed on unencrypted volumes. The fix had only shipped on the `release/*-omf-encrypted` branches; PR #35 (which targeted main) was closed unmerged. This re-lands it on main so a tagged release carries it.

Scope: changes only the StorageClass `parameters`. Existing PVs are unaffected; newly-provisioned volumes will be encrypted. The SC object may be replaced on apply (harmless — no data lives on the SC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)