### PR TITLE
Revert EKS access-entry moved/prevent_destroy blocks (keep TF clean)

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -89,38 +89,11 @@ resource "aws_security_group_rule" "eks_nodes_all_vpc_ingress" {
   description       = "Allow all traffic from within VPC for node-to-node/pod-to-pod communication"
 }
 
-# This resource was migrated from `count` (single principal, address `[0]`) to
-# `for_each` (map keyed by name). Without the moved blocks below, Terraform reads
-# the address change `[0]` -> `["admin"]` as destroy+recreate, which deletes the
-# admin EKS access entry mid-apply and locks operators out of the cluster. The
-# moved blocks carry the existing object to the new key instead. They assume the
-# previously-single principal is passed under the map key "admin" (the convention
-# in the root configs); an env that used a different key must adjust accordingly.
-# Already-migrated states have nothing at `[0]`, so the moved block is a safe no-op.
-moved {
-  from = aws_eks_access_entry.access[0]
-  to   = aws_eks_access_entry.access["admin"]
-}
-
-moved {
-  from = aws_eks_access_policy_association.access_policy[0]
-  to   = aws_eks_access_policy_association.access_policy["admin"]
-}
-
 resource "aws_eks_access_entry" "access" {
   for_each      = var.eks_access_principal_arn
   cluster_name  = module.eks.cluster_name
   principal_arn = each.value
   type          = "STANDARD"
-
-  # Guardrail: refuse to destroy an admin access entry. A future address change
-  # or an accidental removal will then fail the plan loudly instead of silently
-  # revoking cluster access (the failure mode that originally locked us out). To
-  # intentionally revoke a principal, remove it from the map AND drop this block
-  # in the same change.
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_eks_access_policy_association" "access_policy" {


### PR DESCRIPTION
Reverts #44 (`5a1a4d2`, the `moved` blocks + `prevent_destroy` on the EKS access entries).

### Why
We want the module TF to stay clean — no `moved` blocks and no `prevent_destroy` lifecycle. With this reverted, consumers on the older `count`-based state will see the admin access entry as a destroy+recreate on first apply (rather than a state move). That one-time recreate is acceptable: if it transiently drops admin access, it's re-added manually and the next apply is clean.

### Net effect
After this, `main` equals `778e6f5` (PR #39 argocd merge) + import-block removal (#45) + gp3 StorageClass encryption (#47), with **no** moved/prevent_destroy blocks. Verified the resulting tree is byte-identical to that intended state.

The access entries remain `for_each`-based (introduced in #39); only the migration-safety blocks are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)