### PR TITLE
Make enable_cluster_creator_admin_permissions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ module "nx" {
 | `cluster_iam_role_arn` | Cluster IAM role ARN | - |
 | `create_iam_role` | Create cluster IAM role (false if using nx-iam-tf) | `false` |
 | `eks_managed_node_groups` | Map of node group definitions | `{}` |
+| `enable_cluster_creator_admin_permissions` | Grant the identity running terraform cluster-admin; set `false` to avoid access-entry/KMS drift when plan/apply use different IAM principals | `true` |
 | `enable_efs` | Enable EFS filesystem and CSI driver | `false` |
 
 ### Pod Identity Role ARNs

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -19,7 +19,7 @@ module "eks" {
   create_iam_role                          = var.create_iam_role
   iam_role_arn                             = var.cluster_iam_role_arn
   eks_managed_node_groups                  = var.eks_managed_node_groups
-  enable_cluster_creator_admin_permissions = true
+  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
 
   addons = merge(
     {

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,12 @@ variable "create_iam_role" {
   default     = false
 }
 
+variable "enable_cluster_creator_admin_permissions" {
+  description = "Grant the identity running terraform a cluster-admin access entry. Set to false when plan and apply run as different IAM principals (e.g. separate CI plan/apply roles) to avoid perpetual access-entry + KMS key policy drift; manage admin access explicitly via eks_access_principal_arn instead."
+  type        = bool
+  default     = true
+}
+
 variable "eks_managed_node_groups" {
   description = "Map of EKS managed node group definitions to create"
   type        = any


### PR DESCRIPTION
Fixes #46.

## What

Surfaces `enable_cluster_creator_admin_permissions` as an input variable (default `true`) instead of hardcoding it in `eks-cluster.tf:22`.

## Why

The hardcoded `true` makes the EKS module create an access entry + `AmazonEKSClusterAdminPolicy` association for `data.aws_caller_identity.current.arn`, and bakes that same ARN into the cluster KMS key policy principal. When `plan` and `apply` run as **different IAM principals** (e.g. separate CI `*-plan` ReadOnly and `*-apply` Administrator roles), every plan shows:

- `module.eks.aws_eks_access_entry.this["cluster_creator"]` — must be replaced
- `module.eks.aws_eks_access_policy_association.this["cluster_creator_admin"]` — must be replaced
- `module.eks.module.kms.aws_kms_key.this[0]` — in-place policy update

The entry/KMS principal oscillates between the two identities on every apply.

## Change

- New `bool` variable `enable_cluster_creator_admin_permissions`, default `true` — no behavior change for existing consumers.
- Consumers hitting the drift set it to `false` and manage cluster-admin access explicitly via the existing `eks_access_principal_arn` map.
- README EKS variable table updated.

This is option 1 from the issue.