### PR TITLE
Expose OpenSearch advanced_options as a configurable input

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ module "nx" {
 | `opensearch_coordinator_instance_type` | Coordinator node instance type | `""` |
 | `opensearch_ebs_iops` | EBS provisioned IOPS | `null` |
 | `opensearch_ebs_throughput` | EBS throughput (MiB/s) for gp3 | `null` |
+| `opensearch_advanced_options` | Extra `advanced_options` merged over computed defaults (consumer keys win); codify overrides like `override_main_response_version` to avoid phantom drift | `{}` |
 
 ---
 

--- a/open-search.tf
+++ b/open-search.tf
@@ -46,9 +46,12 @@ locals {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 
-  advanced_options = local.supports_override_response_version ? merge(local.advanced_options_base, {
+  advanced_options_computed = local.supports_override_response_version ? merge(local.advanced_options_base, {
     "override_main_response_version" = "false"
   }) : local.advanced_options_base
+
+  # Consumer-supplied overrides win over the computed defaults.
+  advanced_options = merge(local.advanced_options_computed, var.opensearch_advanced_options)
 }
 
 # OpenSearch module configuration

--- a/variables.tf
+++ b/variables.tf
@@ -578,6 +578,12 @@ variable "engine_version" {
   type        = string
 }
 
+variable "opensearch_advanced_options" {
+  description = "Additional advanced_options to set on the OpenSearch domain, merged over the module's computed defaults (consumer keys win). Use to codify operational overrides such as override_main_response_version that would otherwise show as perpetual phantom drift (OpenSearch UpdateDomainConfig has PATCH, not REPLACE, semantics for advancedOptions)."
+  type        = map(string)
+  default     = {}
+}
+
 variable "enable_masternodes" {
   description = "Enable master nodes for OpenSearch"
   type        = bool


### PR DESCRIPTION
Fixes #36.

## What

Adds an `opensearch_advanced_options` input variable (`map(string)`, default `{}`), merged over the module's computed `advanced_options` so consumer-supplied keys win.

## Why

`open-search.tf` computed `advanced_options` internally with no way for consumers to add or override entries short of forking. OpenSearch's `UpdateDomainConfig` API has **PATCH** (not REPLACE) semantics for `advancedOptions`, so any key set out-of-band on the live domain persists on the AWS side regardless of TF intent. At PlatformScience the live `nvisionx` domain has `override_main_response_version = "true"` (set years ago for Elasticsearch API compatibility); since the module never declares it, every plan shows a phantom in-place update that "removes" the key, and there was no clean way to codify it in TF.

## Change

- New variable `opensearch_advanced_options` (default `{}`).
- The existing version-aware logic now computes `local.advanced_options_computed`; the final `local.advanced_options` is `merge(computed, var.opensearch_advanced_options)` — consumer keys override.
- Default `{}` is a no-op, so **no behavior change** for existing consumers. The version-aware `override_main_response_version` default is preserved.
- README OpenSearch variable table updated.

### Note vs. the issue proposal

The issue suggested replacing the hardcoded 3-key literal with a variable default. Since the file has since gained version-aware logic (it conditionally adds `override_main_response_version` based on engine major version), I kept that intelligence and made the variable an *override layer* on top instead of replacing it — so PS sets `{ override_main_response_version = "true" }` without losing the version gating.