### PR TITLE
Use kubernetes_*_v1 resources to clear deprecation warnings

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -121,7 +121,7 @@ locals {
 }
 
 
-resource "kubernetes_config_map" "infra_config" {
+resource "kubernetes_config_map_v1" "infra_config" {
   metadata {
     name      = "infra-config"
     namespace = "default"
@@ -168,7 +168,7 @@ resource "kubernetes_config_map" "infra_config" {
 }
 
 
-resource "kubernetes_secret" "infra_secrets" {
+resource "kubernetes_secret_v1" "infra_secrets" {
   count = var.enable_postgres && var.enable_opensearch ? 1 : 0
 
   metadata {
@@ -209,7 +209,7 @@ locals {
   })
 }
 
-resource "kubernetes_secret" "docker_hub" {
+resource "kubernetes_secret_v1" "docker_hub" {
   count = length(trimspace(var.docker_hub_username)) > 0 && length(trimspace(var.docker_hub_token)) > 0 ? 1 : 0
 
   metadata {
@@ -225,7 +225,7 @@ resource "kubernetes_secret" "docker_hub" {
   }
 }
 
-resource "kubernetes_secret" "github_cr" {
+resource "kubernetes_secret_v1" "github_cr" {
   count = length(trimspace(var.github_cr_username)) > 0 && length(trimspace(var.github_cr_token)) > 0 ? 1 : 0
 
   metadata {
@@ -262,8 +262,27 @@ resource "kubernetes_storage_class_v1" "gp3" {
   }
 }
 
+# Migrate state from the deprecated unsuffixed kubernetes_* resources to their
+# _v1 equivalents without recreation.
+moved {
+  from = kubernetes_config_map.infra_config
+  to   = kubernetes_config_map_v1.infra_config
+}
 
+moved {
+  from = kubernetes_secret.infra_secrets
+  to   = kubernetes_secret_v1.infra_secrets
+}
 
+moved {
+  from = kubernetes_secret.docker_hub
+  to   = kubernetes_secret_v1.docker_hub
+}
+
+moved {
+  from = kubernetes_secret.github_cr
+  to   = kubernetes_secret_v1.github_cr
+}
 
 
 


### PR DESCRIPTION
Fixes #37.

## What

Renames the deprecated unsuffixed `kubernetes_*` resources in `eks-cluster.tf` to their `_v1` equivalents and adds `moved` blocks so existing state migrates in place (no recreation).

## Why

The `hashicorp/kubernetes` provider (v3.x) marks `kubernetes_config_map` and `kubernetes_secret` deprecated in favor of `*_v1`. They emit a `Deprecated Resource` warning on every downstream `terraform plan`, adding noise that obscures new warnings, and the unsuffixed names are slated for removal in a future major provider release.

## Change

Four resources renamed (the issue listed three; `kubernetes_secret.github_cr` has the same deprecation, so it is included for completeness):

- `kubernetes_config_map.infra_config` → `kubernetes_config_map_v1.infra_config`
- `kubernetes_secret.infra_secrets` → `kubernetes_secret_v1.infra_secrets`
- `kubernetes_secret.docker_hub` → `kubernetes_secret_v1.docker_hub`
- `kubernetes_secret.github_cr` → `kubernetes_secret_v1.github_cr`

Each gets a `moved` block, so a downstream `plan` after bumping the pinned ref shows the state moves with **no destroy/recreate** and no resource diff. `kubernetes_storage_class_v1` in the same file already uses the v1 convention, so this aligns the rest of the file.

No cross-references to these resource addresses exist elsewhere in the module (checked outputs / other `.tf` files), so no other edits are needed. Behavior is otherwise unchanged.

## Downstream

Consumers (e.g. `platformscience/nvisionx-infrastructure`) bump the pinned module ref after this ships; the `moved` blocks handle the state transition automatically.