### PR TITLE
Configurable cluster-admin + OpenSearch advanced_options, and kubernetes_*_v1 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ module "nx" {
 | `opensearch_coordinator_instance_type` | Coordinator node instance type | `""` |
 | `opensearch_ebs_iops` | EBS provisioned IOPS | `null` |
 | `opensearch_ebs_throughput` | EBS throughput (MiB/s) for gp3 | `null` |
+| `opensearch_advanced_options` | Extra `advanced_options` merged over computed defaults (consumer keys win); codify overrides like `override_main_response_version` to avoid phantom drift | `{}` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ module "nx" {
 | `cluster_iam_role_arn` | Cluster IAM role ARN | - |
 | `create_iam_role` | Create cluster IAM role (false if using nx-iam-tf) | `false` |
 | `eks_managed_node_groups` | Map of node group definitions | `{}` |
+| `enable_cluster_creator_admin_permissions` | Grant the identity running terraform cluster-admin; set `false` to avoid access-entry/KMS drift when plan/apply use different IAM principals | `true` |
 | `enable_efs` | Enable EFS filesystem and CSI driver | `false` |
 
 ### Pod Identity Role ARNs

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -19,7 +19,7 @@ module "eks" {
   create_iam_role                          = var.create_iam_role
   iam_role_arn                             = var.cluster_iam_role_arn
   eks_managed_node_groups                  = var.eks_managed_node_groups
-  enable_cluster_creator_admin_permissions = true
+  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
 
   addons = merge(
     {

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -121,7 +121,7 @@ locals {
 }
 
 
-resource "kubernetes_config_map" "infra_config" {
+resource "kubernetes_config_map_v1" "infra_config" {
   metadata {
     name      = "infra-config"
     namespace = "default"
@@ -168,7 +168,7 @@ resource "kubernetes_config_map" "infra_config" {
 }
 
 
-resource "kubernetes_secret" "infra_secrets" {
+resource "kubernetes_secret_v1" "infra_secrets" {
   count = var.enable_postgres && var.enable_opensearch ? 1 : 0
 
   metadata {
@@ -209,7 +209,7 @@ locals {
   })
 }
 
-resource "kubernetes_secret" "docker_hub" {
+resource "kubernetes_secret_v1" "docker_hub" {
   count = length(trimspace(var.docker_hub_username)) > 0 && length(trimspace(var.docker_hub_token)) > 0 ? 1 : 0
 
   metadata {
@@ -225,7 +225,7 @@ resource "kubernetes_secret" "docker_hub" {
   }
 }
 
-resource "kubernetes_secret" "github_cr" {
+resource "kubernetes_secret_v1" "github_cr" {
   count = length(trimspace(var.github_cr_username)) > 0 && length(trimspace(var.github_cr_token)) > 0 ? 1 : 0
 
   metadata {
@@ -262,8 +262,27 @@ resource "kubernetes_storage_class_v1" "gp3" {
   }
 }
 
+# Migrate state from the deprecated unsuffixed kubernetes_* resources to their
+# _v1 equivalents without recreation.
+moved {
+  from = kubernetes_config_map.infra_config
+  to   = kubernetes_config_map_v1.infra_config
+}
 
+moved {
+  from = kubernetes_secret.infra_secrets
+  to   = kubernetes_secret_v1.infra_secrets
+}
 
+moved {
+  from = kubernetes_secret.docker_hub
+  to   = kubernetes_secret_v1.docker_hub
+}
+
+moved {
+  from = kubernetes_secret.github_cr
+  to   = kubernetes_secret_v1.github_cr
+}
 
 
 

--- a/open-search.tf
+++ b/open-search.tf
@@ -46,9 +46,12 @@ locals {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 
-  advanced_options = local.supports_override_response_version ? merge(local.advanced_options_base, {
+  advanced_options_computed = local.supports_override_response_version ? merge(local.advanced_options_base, {
     "override_main_response_version" = "false"
   }) : local.advanced_options_base
+
+  # Consumer-supplied overrides win over the computed defaults.
+  advanced_options = merge(local.advanced_options_computed, var.opensearch_advanced_options)
 }
 
 # OpenSearch module configuration

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,12 @@ variable "create_iam_role" {
   default     = false
 }
 
+variable "enable_cluster_creator_admin_permissions" {
+  description = "Grant the identity running terraform a cluster-admin access entry. Set to false when plan and apply run as different IAM principals (e.g. separate CI plan/apply roles) to avoid perpetual access-entry + KMS key policy drift; manage admin access explicitly via eks_access_principal_arn instead."
+  type        = bool
+  default     = true
+}
+
 variable "eks_managed_node_groups" {
   description = "Map of EKS managed node group definitions to create"
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -584,6 +584,12 @@ variable "engine_version" {
   type        = string
 }
 
+variable "opensearch_advanced_options" {
+  description = "Additional advanced_options to set on the OpenSearch domain, merged over the module's computed defaults (consumer keys win). Use to codify operational overrides such as override_main_response_version that would otherwise show as perpetual phantom drift (OpenSearch UpdateDomainConfig has PATCH, not REPLACE, semantics for advancedOptions)."
+  type        = map(string)
+  default     = {}
+}
+
 variable "enable_masternodes" {
   description = "Enable master nodes for OpenSearch"
   type        = bool


### PR DESCRIPTION
Combines three related module-input/cleanup fixes into one PR. Each is an independent commit and verified with `terraform init -backend=false && terraform validate`.

Fixes #46, fixes #36, fixes #37.

---

## 1. Make `enable_cluster_creator_admin_permissions` configurable (#46)

`eks-cluster.tf` hardcoded `enable_cluster_creator_admin_permissions = true`, which bakes the running identity into the EKS access entry and cluster KMS key policy. When `plan` and `apply` run as **different IAM principals** (e.g. separate CI `*-plan` ReadOnly and `*-apply` Administrator roles), the access entry + KMS principal oscillate on every plan/apply.

- New `bool` variable `enable_cluster_creator_admin_permissions`, **default `true`** — no behavior change.
- Consumers hitting the drift set it `false` and manage admin access via the existing `eks_access_principal_arn` map.

## 2. Expose OpenSearch `advanced_options` as a configurable input (#36)

`open-search.tf` computed `advanced_options` internally with no way to add/override keys. Because `UpdateDomainConfig` has **PATCH** (not REPLACE) semantics for `advancedOptions`, any key set out-of-band on the live domain (e.g. `override_main_response_version = "true"` at PlatformScience) persists on the AWS side and shows as perpetual phantom drift.

- New `opensearch_advanced_options` (`map(string)`, **default `{}`**), merged **over** the module's existing version-aware computed defaults so consumer keys win.
- The version-aware `override_main_response_version` logic is retained; default `{}` is a no-op.

## 3. Use `kubernetes_*_v1` resources to clear deprecation warnings (#37)

The `hashicorp/kubernetes` v3 provider deprecated the unsuffixed `kubernetes_config_map` / `kubernetes_secret` resources; they emit a warning on every downstream `plan` and are slated for removal in a future major release.

- Renamed all four affected resources to `*_v1`: `infra_config`, `infra_secrets`, `docker_hub`, `github_cr` (the issue listed three; `github_cr` has the same deprecation, included for completeness).
- Added a `moved` block per resource so existing state migrates **in place, no recreation**.
- `validate` confirms this removes exactly the 4 config_map/secret warnings (remaining `kubernetes_namespace` deprecations are out of scope for #37).

---

## Verification

- `terraform fmt -check` clean on all changed `.tf` files.
- `terraform init -backend=false && terraform validate` succeeds.
- All three defaults preserve current behavior, so existing consumers see no diff beyond the `moved` state migration.

## Downstream

Consumers (e.g. `platformscience/nvisionx-infrastructure`) bump the pinned module ref after this ships; the `moved` blocks handle the state transition automatically.
