### PR TITLE
Drop kubernetes moved blocks (incompatible with kubernetes provider 2.x)

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -262,27 +262,5 @@ resource "kubernetes_storage_class_v1" "gp3" {
   }
 }
 
-# Migrate state from the deprecated unsuffixed kubernetes_* resources to their
-# _v1 equivalents without recreation.
-moved {
-  from = kubernetes_config_map.infra_config
-  to   = kubernetes_config_map_v1.infra_config
-}
-
-moved {
-  from = kubernetes_secret.infra_secrets
-  to   = kubernetes_secret_v1.infra_secrets
-}
-
-moved {
-  from = kubernetes_secret.docker_hub
-  to   = kubernetes_secret_v1.docker_hub
-}
-
-moved {
-  from = kubernetes_secret.github_cr
-  to   = kubernetes_secret_v1.github_cr
-}
-
 
 


### PR DESCRIPTION
Follow-up to #52.

## Problem

The `moved` blocks added in #52 (renaming `kubernetes_config_map`/`kubernetes_secret` → `*_v1`) make `terraform plan` **hard-error** for any consumer on the `hashicorp/kubernetes` `~> 2.x` provider:

```
Error: Move Resource State Not Supported
The "kubernetes_secret_v1" resource type does not support moving resource state across resource types.
```

A cross-type `moved` block requires the provider to implement the `MoveResourceState` RPC; provider 2.x does not. (And the deprecation warnings the `_v1` rename targeted only appear on provider **3.x**, so on 2.x the rename was cost-without-benefit.)

## Change

- **Keep** the `_v1` resource names (they are the non-deprecated names and valid on both 2.x and 3.x).
- **Remove** the four `moved` blocks (the only thing erroring).

## Migration impact (consumers on provider 2.x)

Without the `moved` blocks, the four `default`-namespace objects (`infra-config`, `infra-secrets`, `docker-hub-secret`, `github-cr-secret`) are **destroyed and recreated** on upgrade. Content is identical (sourced from Secrets Manager / config), so it is a short, accepted downtime — running pods are unaffected (envFrom reads at start); only a pod start or image pull during the gap would hiccup.

Because old and new addresses manage the same named K8s object, apply ordering can otherwise hit `AlreadyExists`. To guarantee a clean apply, delete the four live objects first:

```
kubectl -n default delete configmap infra-config
kubectl -n default delete secret infra-secrets docker-hub-secret github-cr-secret
terraform apply
```

## Verification

- `terraform fmt -check` clean; `terraform init -backend=false && terraform validate` pass.

## Follow-up

#37 (clearing the provider deprecation warnings via `_v1`) is properly resolved only once consumers move to the kubernetes **3.x** provider, where the `moved` blocks become valid and the migration is automatic. Track it there.